### PR TITLE
Adding Favorites Functionality

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,5 +88,7 @@ dependencies {
 
     // Jetpack Compose Integration
     implementation("androidx.navigation:navigation-compose:$nav_version")
-    //implementation("androidx.navigation:navigation-compose:$nav_version")
+
+    // Preferences DataStore (SharedPreferences like APIs)
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
 }

--- a/app/src/main/java/com/wpi/audiojournal/StoreData.kt
+++ b/app/src/main/java/com/wpi/audiojournal/StoreData.kt
@@ -1,0 +1,43 @@
+package com.wpi.audiojournal
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.wpi.audiojournal.models.MenuItem
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+
+class StoreData(private val context: Context) {
+    companion object {
+        private val Context.dataStore: DataStore<Preferences> by preferencesDataStore("AJODataStore")
+    }
+
+    suspend fun addFavorite(name: String, link: String){
+        context.dataStore.edit { preferences ->
+            preferences[stringPreferencesKey(name)] = link
+        }
+    }
+
+    suspend fun deleteFavorite(name: String){
+        context.dataStore.edit {
+            it.remove(stringPreferencesKey(name))
+        }
+    }
+
+    suspend fun isFavorite(name: String): Boolean {
+        return context.dataStore.data.first().contains(stringPreferencesKey(name))
+    }
+
+     fun createButtons(): List<MenuItem> {
+        var buttons: MutableList<MenuItem> = mutableListOf()
+         val exampleData = runBlocking { context.dataStore.data.first() }
+
+         exampleData.asMap().mapKeys {
+             buttons.add(MenuItem(it.key.name, it.value.toString()))
+         }
+        return buttons
+    }
+}

--- a/app/src/main/java/com/wpi/audiojournal/navigation/NavGraph.kt
+++ b/app/src/main/java/com/wpi/audiojournal/navigation/NavGraph.kt
@@ -1,13 +1,16 @@
 package com.wpi.audiojournal.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.wpi.audiojournal.StoreData
 import com.wpi.audiojournal.models.MenuItem
 import com.wpi.audiojournal.screen.SplashScreen
 import com.wpi.audiojournal.ui.theme.ColorScheme
 import com.wpi.audiojournal.view.*
+import com.wpi.audiojournal.viewmodels.FavoritesViewModel
 
 @Composable
 fun SetupNavGraph(navController: NavHostController, setColorScheme: (ColorScheme) -> Unit) {
@@ -23,7 +26,7 @@ fun SetupNavGraph(navController: NavHostController, setColorScheme: (ColorScheme
                     MenuItem("Listen Live", "listen-live"),
                     MenuItem("Archived Programs", "archived-programs"),
                     MenuItem("Resume Last Broadcast", ""),
-                    MenuItem("Favorite Programs", ""),
+                    MenuItem("Favorite Programs", "favorite-programs"),
                     MenuItem("Program Schedule", "program-schedule"),
                     MenuItem("Help", "help")
                 ),
@@ -69,10 +72,12 @@ fun SetupNavGraph(navController: NavHostController, setColorScheme: (ColorScheme
         composable("program-detail/{menuTitle}/{name}") { navBackStackEntry ->
             val title = navBackStackEntry.arguments?.getDecodedString("menuTitle") ?: ""
             val name = navBackStackEntry.arguments?.getDecodedString("name") ?: ""
+            val viewModel = FavoritesViewModel(StoreData(LocalContext.current))
             ProgramDetailView(
                 navController = navController,
                 title = title,
-                name = name
+                name = name,
+                viewModel
             )
         }
 
@@ -86,6 +91,10 @@ fun SetupNavGraph(navController: NavHostController, setColorScheme: (ColorScheme
             MediaPlayerView(title = title, uriString = uriLink)
         }
 
+        composable("favorite-programs"){
+            val viewModel = FavoritesViewModel(StoreData(LocalContext.current))
+            FavoritesView(menuItems = viewModel.createFavoritesButtons(), navController = navController)
+        }
 
         composable("help") {
             HelpMenuView(

--- a/app/src/main/java/com/wpi/audiojournal/view/FavoritesView.kt
+++ b/app/src/main/java/com/wpi/audiojournal/view/FavoritesView.kt
@@ -1,0 +1,14 @@
+package com.wpi.audiojournal.view
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavController
+import com.wpi.audiojournal.models.MenuItem
+import com.wpi.audiojournal.ui.component.Menu
+import com.wpi.audiojournal.ui.component.PageSkeleton
+
+@Composable
+fun FavoritesView(menuItems: List<MenuItem>, navController: NavController){
+    PageSkeleton(header = "Favorite Programs") {
+        Menu(menuItems = menuItems, navController = navController)
+    }
+}

--- a/app/src/main/java/com/wpi/audiojournal/view/ProgramDetailView.kt
+++ b/app/src/main/java/com/wpi/audiojournal/view/ProgramDetailView.kt
@@ -1,18 +1,26 @@
 package com.wpi.audiojournal.view
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.IconButton
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
-
+import com.wpi.audiojournal.R
 import com.wpi.audiojournal.ui.component.Loading
 import com.wpi.audiojournal.ui.component.Menu
 import com.wpi.audiojournal.ui.component.PageSkeleton
 import com.wpi.audiojournal.viewmodels.ProgramViewModel
+import com.wpi.audiojournal.viewmodels.FavoritesViewModel
 
 @Composable
-fun ProgramDetailView(navController: NavController, title: String, name: String, viewModel: ProgramViewModel = viewModel()){
+fun ProgramDetailView(navController: NavController, title: String, name: String, favViewModel: FavoritesViewModel, viewModel: ProgramViewModel = viewModel()){
     LaunchedEffect(name) {
         viewModel.loadEpisodes(name)
     }
@@ -20,6 +28,7 @@ fun ProgramDetailView(navController: NavController, title: String, name: String,
     PageSkeleton(header = title) {
         Loading(data = viewModel.program) { program ->
             Text(text = program.description)
+            FavoritesSection(navController, title, favViewModel)
             program.episodes?.let {
                 Menu(menuItems = it, navController = navController)
             }
@@ -27,4 +36,55 @@ fun ProgramDetailView(navController: NavController, title: String, name: String,
     }
 
 
+}
+
+@Composable
+fun FavoritesSection(navController: NavController, title: String, favViewModel: FavoritesViewModel){
+
+    val gray = R.drawable.favorites_gray
+    val yellow = R.drawable.favorites_yellow
+
+    Row(modifier = Modifier.padding(20.dp)){
+        Text(
+            modifier = Modifier.padding(top=15.dp),
+            text = "Favorite: ",
+//                color = colorResource(id = AppColorSchemes().getContent()),
+        )
+
+        var marked by rememberSaveable {
+            mutableStateOf(favViewModel.isFavorite(title))
+        }
+
+        IconButton(onClick = {
+            marked = !marked
+
+            if(marked){
+                val linkMenuTitle = navController.currentBackStackEntry?.arguments?.getString("menuTitle")
+                val linkName = navController.currentBackStackEntry?.arguments?.getString("name")
+                val link = "program-detail/$linkMenuTitle/$linkName"
+                favViewModel.addFavorite(title, link)
+            }
+            else{
+                favViewModel.deleteFavorite(title)
+            }
+        })
+        {
+            Box(modifier = Modifier
+                .height(50.dp)
+                .width(50.dp)){
+                Image(
+                    painter = painterResource(
+                        id = if (marked) {
+                            yellow
+                        } else {
+                            gray
+                        }
+                    ),
+                    contentDescription = "Favorites",
+                    contentScale = ContentScale.Fit
+                )
+            }
+
+        }
+    }
 }

--- a/app/src/main/java/com/wpi/audiojournal/view/uistates/LivestreamUIState.kt
+++ b/app/src/main/java/com/wpi/audiojournal/view/uistates/LivestreamUIState.kt
@@ -1,0 +1,5 @@
+package com.wpi.audiojournal.view.uistates
+
+class LivestreamUIState (
+    var link: List<String> = listOf()
+)

--- a/app/src/main/java/com/wpi/audiojournal/viewmodels/FavoritesViewModel.kt
+++ b/app/src/main/java/com/wpi/audiojournal/viewmodels/FavoritesViewModel.kt
@@ -1,0 +1,33 @@
+package com.wpi.audiojournal.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wpi.audiojournal.StoreData
+import com.wpi.audiojournal.models.MenuItem
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+class FavoritesViewModel(private val storage: StoreData): ViewModel(){
+
+      fun addFavorite(name: String, link: String){
+          viewModelScope.launch(Dispatchers.IO) {
+              storage.addFavorite(name, link)
+          }
+    }
+
+     fun deleteFavorite(name: String){
+         viewModelScope.launch(Dispatchers.IO) {
+             storage.deleteFavorite(name)
+         }
+    }
+
+     fun isFavorite(name: String): Boolean =
+         runBlocking(Dispatchers.IO) {
+             return@runBlocking storage.isFavorite(name)
+         }
+
+    fun createFavoritesButtons(): List<MenuItem>{
+        return storage.createButtons()
+    }
+}


### PR DESCRIPTION
## Motivation
Adding favorites functionality to allow users to favorite programs and save to data

## Description

Using the DataStore library to save key-value pairs in memory, I created a StoreData class that saves any favorited program by saving the key as the name of the program and the value as the link (program-detail/menuItem/name). The favorites viewModel calls the appropriate method from the StoreData class, and the app renders buttons for each program that is favorited.

## Screenshot / Video
[favoritesFeature.webm](https://user-images.githubusercontent.com/89553998/200459290-c9f29728-8264-4b57-9894-542adfb15c99.webm)

## Checklist
- [x] Builds successfully
- [x] Tested in emulator
