### PR TITLE
adding resume last broadcast functionality

### DIFF
--- a/app/src/main/java/com/wpi/audiojournal/StoreData.kt
+++ b/app/src/main/java/com/wpi/audiojournal/StoreData.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.wpi.audiojournal.models.MenuItem
@@ -12,7 +13,10 @@ import kotlinx.coroutines.runBlocking
 
 class StoreData(private val context: Context) {
     companion object {
-        private val Context.dataStore: DataStore<Preferences> by preferencesDataStore("AJODataStore")
+        private val Context.dataStore: DataStore<Preferences> by preferencesDataStore("DataStoreAJO")
+        val title = stringPreferencesKey("title")
+        val playTime = longPreferencesKey("playTime")
+        val programURL = stringPreferencesKey("link")
     }
 
     suspend fun addFavorite(name: String, link: String){
@@ -36,8 +40,29 @@ class StoreData(private val context: Context) {
          val exampleData = runBlocking { context.dataStore.data.first() }
 
          exampleData.asMap().mapKeys {
-             buttons.add(MenuItem(it.key.name, it.value.toString()))
+             if(it.key.name != "title" && it.key.name != "playTime" && it.key.name != "link")
+                buttons.add(MenuItem(it.key.name, it.value.toString()))
          }
         return buttons
+    }
+
+    suspend fun addLastPlayed(header: String, programLink: String, play: Long){
+        context.dataStore.edit { preferences ->
+            preferences[title] = header
+            preferences[playTime] = play
+            preferences[programURL] = programLink
+        }
+    }
+
+     fun getPlayTime(): Long? {
+        return runBlocking {context.dataStore.data.first()[playTime]}
+    }
+
+    fun getTitle(): String? {
+        return runBlocking {context.dataStore.data.first()[title]}
+    }
+
+    fun getProgramLink(): String? {
+        return runBlocking {context.dataStore.data.first()[programURL]}
     }
 }

--- a/app/src/main/java/com/wpi/audiojournal/navigation/NavGraph.kt
+++ b/app/src/main/java/com/wpi/audiojournal/navigation/NavGraph.kt
@@ -25,7 +25,7 @@ fun SetupNavGraph(navController: NavHostController, setColorScheme: (ColorScheme
                 menuItems = listOf(
                     MenuItem("Listen Live", "listen-live"),
                     MenuItem("Archived Programs", "archived-programs"),
-                    MenuItem("Resume Last Broadcast", ""),
+                    MenuItem("Resume Last Broadcast", "resume-last-broadcast"),
                     MenuItem("Favorite Programs", "favorite-programs"),
                     MenuItem("Program Schedule", "program-schedule"),
                     MenuItem("Help", "help")
@@ -88,7 +88,18 @@ fun SetupNavGraph(navController: NavHostController, setColorScheme: (ColorScheme
         composable("media-player/{menuTitle}/{uriLink}"){navBackStackEntry ->
             val title = navBackStackEntry.arguments?.getDecodedString("menuTitle") ?: ""
             val uriLink = navBackStackEntry.arguments?.getDecodedString("uriLink") ?: ""
-            MediaPlayerView(title = title, uriString = uriLink)
+            MediaPlayerView(title = title, uriString = uriLink, playTime = 0L)
+        }
+
+        composable("resume-last-broadcast"){
+            val viewModel = FavoritesViewModel(StoreData(LocalContext.current))
+            val title = viewModel.getTitle()
+            val playTime = viewModel.getPlayTime()
+            val link = viewModel.getProgramLink()
+
+            if (title != null && link != null && playTime != null) {
+                    MediaPlayerView(title = title, uriString = link, playTime = playTime)
+            }
         }
 
         composable("favorite-programs"){

--- a/app/src/main/java/com/wpi/audiojournal/view/MediaPlayerView.kt
+++ b/app/src/main/java/com/wpi/audiojournal/view/MediaPlayerView.kt
@@ -15,7 +15,7 @@ import com.wpi.audiojournal.R
 import com.wpi.audiojournal.ui.component.PageSkeleton
 
 @Composable
-fun MediaPlayerView(title: String, uriString: String) {
+fun MediaPlayerView(title: String, uriString: String, playTime: Long) {
     PageSkeleton(header = title) {
         Image(
             painter = painterResource(id = R.drawable.loading_screen_mic),
@@ -26,7 +26,7 @@ fun MediaPlayerView(title: String, uriString: String) {
                 .fillMaxWidth(0.5F)
         )
         Player (Uri.parse(uriString.replace("http:", "https:"))) {
-            Controls(it)
+            Controls(it, title, playTime, uriString)
         }
     }
 }

--- a/app/src/main/java/com/wpi/audiojournal/viewmodels/FavoritesViewModel.kt
+++ b/app/src/main/java/com/wpi/audiojournal/viewmodels/FavoritesViewModel.kt
@@ -30,4 +30,22 @@ class FavoritesViewModel(private val storage: StoreData): ViewModel(){
     fun createFavoritesButtons(): List<MenuItem>{
         return storage.createButtons()
     }
+
+    fun addLastPlayed(title: String, programLink: String, play: Long){
+        viewModelScope.launch(Dispatchers.IO){
+            storage.addLastPlayed(title, programLink, play)
+        }
+    }
+
+    fun getPlayTime(): Long? {
+        return storage.getPlayTime()
+    }
+
+    fun getTitle(): String? {
+        return storage.getTitle()
+    }
+
+    fun getProgramLink(): String? {
+        return storage.getProgramLink()
+    }
 }


### PR DESCRIPTION
## Motivation
Adding resume last broadcast functionality

## Description

Added 3 keys in DataStore for the page title, player time to resume at, and uri of the audio file. Pulls from the favorites view model to keep in one viewmodel, and sets appropriately in the controls composable. There might be a small issue with the player time not being saved accurately if someone runs the app in the background (because it seems the player time can't be tracked when running the app in the background?), but we can look into that later.

## Screenshot / Video

## Checklist
- [x] Builds successfully
- [x] Tested in emulator
