### PR TITLE
Fix Theme NPE.

### DIFF
--- a/app/src/main/java/com/wpi/audiojournal/ui/theme/Theme.kt
+++ b/app/src/main/java/com/wpi/audiojournal/ui/theme/Theme.kt
@@ -82,7 +82,7 @@ fun AudioJournalTheme(darkTheme: Boolean = isSystemInDarkTheme(),
                       content: @Composable ((ColorScheme) -> Unit) -> Unit) {
     val viewModel = FavoritesViewModel(StoreData(LocalContext.current))
     val (colorScheme, setColorScheme) = remember {
-        mutableStateOf(colorSchemes[viewModel.getColorScheme()!!])
+        mutableStateOf(colorSchemes[viewModel.getColorScheme() ?: 0])
     }
 
     val colors = if (darkTheme) {


### PR DESCRIPTION
Fixes a bug that causes a fresh install of the app to crash with a NPE, as no theme has yet been saved.

## Checklist
- [X] Builds successfully
- [X] Tested in emulator
