### PR TITLE
Prevent app from crashing on network error.

### DIFF
--- a/app/src/main/java/com/wpi/audiojournal/repositories/AudioJournalService.kt
+++ b/app/src/main/java/com/wpi/audiojournal/repositories/AudioJournalService.kt
@@ -1,16 +1,21 @@
 package com.wpi.audiojournal.repositories
 
+import android.content.Context
 import android.net.Uri
+import android.widget.Toast
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.wpi.audiojournal.models.*
+import kotlinx.coroutines.CoroutineExceptionHandler
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.http.GET
 import retrofit2.http.Path
+import java.net.SocketException
+import java.net.UnknownHostException
 
 const val BASE_URL = "https://audiojournal.org/wp-json/swws/v1/"
 
@@ -54,4 +59,12 @@ val AudioJournalService: AudioJournalServiceInterface by lazy {
         .baseUrl(BASE_URL)
         .build()
         .create(AudioJournalServiceInterface::class.java)
+}
+
+fun networkHandler (context: Context) = CoroutineExceptionHandler { _, throwable ->
+    when (throwable) {
+        is SocketException -> Toast.makeText(context, "Unstable network connection.", Toast.LENGTH_LONG).show()
+        is UnknownHostException -> Toast.makeText(context, "Unable to connect to the network.", Toast.LENGTH_LONG).show()
+        else -> throw (throwable)
+    }
 }

--- a/app/src/main/java/com/wpi/audiojournal/viewmodels/ArchiveViewModel.kt
+++ b/app/src/main/java/com/wpi/audiojournal/viewmodels/ArchiveViewModel.kt
@@ -1,18 +1,20 @@
 package com.wpi.audiojournal.viewmodels
 
+import android.app.Application
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.wpi.audiojournal.models.Category
 import com.wpi.audiojournal.repositories.AudioJournalService
+import com.wpi.audiojournal.repositories.networkHandler
 import kotlinx.coroutines.launch
 
-class ArchiveViewModel: ViewModel() {
+class ArchiveViewModel(application: Application) : AndroidViewModel(application) {
     var categories: List<Category>? by mutableStateOf(null)
 
-    fun loadCategories() = viewModelScope.launch {
+    fun loadCategories() = viewModelScope.launch(networkHandler(getApplication())) {
         categories = AudioJournalService.getCategories().body() ?: listOf()
     }
 }

--- a/app/src/main/java/com/wpi/audiojournal/viewmodels/CategoryViewModel.kt
+++ b/app/src/main/java/com/wpi/audiojournal/viewmodels/CategoryViewModel.kt
@@ -1,18 +1,20 @@
 package com.wpi.audiojournal.viewmodels
 
+import android.app.Application
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.wpi.audiojournal.models.Program
 import com.wpi.audiojournal.repositories.AudioJournalService
+import com.wpi.audiojournal.repositories.networkHandler
 import kotlinx.coroutines.launch
 
-class CategoryViewModel : ViewModel() {
+class CategoryViewModel(application: Application) : AndroidViewModel(application) {
     var programs: List<Program>? by mutableStateOf(null)
 
-    fun loadPrograms(category: String) = viewModelScope.launch {
+    fun loadPrograms(category: String) = viewModelScope.launch(networkHandler(getApplication())) {
         programs = AudioJournalService.getPrograms(category).body() ?: listOf()
 
     }

--- a/app/src/main/java/com/wpi/audiojournal/viewmodels/LivestreamViewModel.kt
+++ b/app/src/main/java/com/wpi/audiojournal/viewmodels/LivestreamViewModel.kt
@@ -1,18 +1,20 @@
 package com.wpi.audiojournal.viewmodels
 
+import android.app.Application
 import android.net.Uri
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.wpi.audiojournal.repositories.AudioJournalService
+import com.wpi.audiojournal.repositories.networkHandler
 import kotlinx.coroutines.launch
 
-class LivestreamViewModel: ViewModel() {
+class LivestreamViewModel(application: Application) : AndroidViewModel(application) {
     var uri: Uri? by mutableStateOf(null)
 
-    fun loadUri() = viewModelScope.launch {
+    fun loadUri() = viewModelScope.launch(networkHandler(getApplication())) {
         uri = AudioJournalService.getLiveLink().body()
     }
 }

--- a/app/src/main/java/com/wpi/audiojournal/viewmodels/ProgramViewModel.kt
+++ b/app/src/main/java/com/wpi/audiojournal/viewmodels/ProgramViewModel.kt
@@ -1,19 +1,21 @@
 package com.wpi.audiojournal.viewmodels
 
+import android.app.Application
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.wpi.audiojournal.models.Program
 import com.wpi.audiojournal.repositories.AudioJournalService
+import com.wpi.audiojournal.repositories.networkHandler
 import kotlinx.coroutines.launch
 
 
-class ProgramViewModel : ViewModel() {
+class ProgramViewModel(application: Application) : AndroidViewModel(application) {
     var program: Program? by mutableStateOf(null)
 
-    fun loadEpisodes(name: String) = viewModelScope.launch {
+    fun loadEpisodes(name: String) = viewModelScope.launch(networkHandler(getApplication())) {
         program = AudioJournalService.getProgram(name).body()
     }
 }

--- a/app/src/main/java/com/wpi/audiojournal/viewmodels/ScheduleViewModel.kt
+++ b/app/src/main/java/com/wpi/audiojournal/viewmodels/ScheduleViewModel.kt
@@ -1,18 +1,20 @@
 package com.wpi.audiojournal.viewmodels
 
 
+import android.app.Application
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.wpi.audiojournal.repositories.AudioJournalService
+import com.wpi.audiojournal.repositories.networkHandler
 import kotlinx.coroutines.launch
 
 
-class ScheduleViewModel: ViewModel() {
+class ScheduleViewModel(application: Application) : AndroidViewModel(application) {
     var schedule: Map<String, Map<String, String>>? by mutableStateOf(null)
-    fun loadSchedule() = viewModelScope.launch {
+    fun loadSchedule() = viewModelScope.launch(networkHandler(getApplication())) {
         AudioJournalService.getSchedule().body()?.let {
             schedule = it
         }

--- a/app/src/main/java/com/wpi/audiojournal/viewmodels/SearchProgramsViewModel.kt
+++ b/app/src/main/java/com/wpi/audiojournal/viewmodels/SearchProgramsViewModel.kt
@@ -5,9 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wpi.audiojournal.models.MenuItem
 import com.wpi.audiojournal.models.Program
-
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch


### PR DESCRIPTION
This adds an exception handler to network-related coroutines to catch networking exceptions and show a toast to the user. All other exceptions are re-thrown.

## Checklist
- [X] Builds successfully
- [X] Tested in emulator
