### PR TITLE
Added airtime feature to programs

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <runningDeviceTargetSelectedWithDropDown>
+      <Target>
+        <type value="RUNNING_DEVICE_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="SERIAL_NUMBER" />
+            <value value="ZY22G6FM6S" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-01-13T20:27:33.562522500Z" />
+  </component>
+</project>

--- a/app/src/main/java/com/wpi/audiojournal/MainActivity.kt
+++ b/app/src/main/java/com/wpi/audiojournal/MainActivity.kt
@@ -18,11 +18,13 @@ import com.google.android.exoplayer2.C
 import com.wpi.audiojournal.models.Category
 import com.wpi.audiojournal.models.Program
 import com.wpi.audiojournal.navigation.SetupNavGraph
+import com.wpi.audiojournal.ui.component.GetAirtimeMap
 import com.wpi.audiojournal.ui.component.Loading
 import com.wpi.audiojournal.ui.theme.AudioJournalTheme
 import com.wpi.audiojournal.ui.theme.LocalColorScheme
 import com.wpi.audiojournal.viewmodels.ArchiveViewModel
 import com.wpi.audiojournal.viewmodels.CategoryViewModel
+import com.wpi.audiojournal.viewmodels.ScheduleViewModel
 import kotlin.reflect.jvm.internal.impl.descriptors.Visibilities
 
 class MainActivity : ComponentActivity() {
@@ -45,6 +47,9 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = LocalColorScheme.current.background
                 ) {
+                    GetAirtimeMap()
+
+
                     val navController = rememberNavController()
 
 

--- a/app/src/main/java/com/wpi/audiojournal/ui/component/Airtime.kt
+++ b/app/src/main/java/com/wpi/audiojournal/ui/component/Airtime.kt
@@ -1,0 +1,55 @@
+package com.wpi.audiojournal.ui.component
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.wpi.audiojournal.viewmodels.ScheduleViewModel
+
+val airtimeMap = HashMap<String, HashMap<String, MutableList<String>>>()
+
+@Composable
+fun GetAirtimeMap(viewModel: ScheduleViewModel = viewModel()){
+    viewModel.loadSchedule()
+    val data = viewModel.schedule
+
+    if (data != null) {
+
+        for(day in data.keys){ //go trough each day
+
+            val timeMap = data.get(day) //Get the time and program pair
+
+            if (timeMap != null) {
+
+                for(time in timeMap.keys){ //Go through each time
+                    val prog = timeMap.get(time)
+
+                    if(airtimeMap.get(prog).isNullOrEmpty()){ // if program not in map
+                        //Add the new hashmap with key as day and list of times with 1 time
+                        val airtime = hashMapOf<String, MutableList<String>>()
+                        val timeList = mutableListOf<String>()
+                        timeList.add(time)
+                        airtime.put(day, timeList)
+                        if (prog != null) {
+                            airtimeMap.put(prog, airtime)
+                        }
+                    }else{ //if program in map
+                        val progAirtime =  airtimeMap.get(prog)
+                        if(progAirtime?.get(day).isNullOrEmpty()){ //if program not the same day
+                            //Add day to map
+                            val timeList = mutableListOf<String>()
+                            timeList.add(time)
+                            progAirtime?.put(", "+day, timeList)
+
+                        }else{ //if program ha sthe same day, different time
+                            //add time to list
+                            if (progAirtime != null) {
+                                progAirtime.get(day)?.add(", "+ time)
+                            }
+                        }
+                    }
+
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/wpi/audiojournal/view/ArchiveView.kt
+++ b/app/src/main/java/com/wpi/audiojournal/view/ArchiveView.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import com.wpi.audiojournal.ui.component.GetAirtimeMap
 import com.wpi.audiojournal.ui.component.Loading
 import com.wpi.audiojournal.ui.component.Menu
 import com.wpi.audiojournal.ui.component.PageSkeleton
@@ -23,6 +24,7 @@ import com.wpi.audiojournal.viewmodels.ArchiveViewModel
 
 @Composable
 fun ArchiveView(navController: NavController, viewModel: ArchiveViewModel = viewModel()){
+
     LaunchedEffect(LocalContext.current) {
         viewModel.loadCategories()
     }

--- a/app/src/main/java/com/wpi/audiojournal/view/ProgramDetailView.kt
+++ b/app/src/main/java/com/wpi/audiojournal/view/ProgramDetailView.kt
@@ -20,6 +20,7 @@ import com.wpi.audiojournal.R
 import com.wpi.audiojournal.ui.component.Loading
 import com.wpi.audiojournal.ui.component.Menu
 import com.wpi.audiojournal.ui.component.PageSkeleton
+import com.wpi.audiojournal.ui.component.airtimeMap
 import com.wpi.audiojournal.ui.theme.LocalColorScheme
 import com.wpi.audiojournal.viewmodels.ProgramViewModel
 import com.wpi.audiojournal.viewmodels.FavoritesViewModel
@@ -32,6 +33,19 @@ fun ProgramDetailView(navController: NavController, title: String, name: String,
 
     PageSkeleton(header = title) {
         Loading(data = viewModel.program) { program ->
+            val airtime = airtimeMap.get(program.title)
+            var strAirtime = ""
+            if (airtime != null) {
+
+                for(day in airtime.keys){
+                    strAirtime = strAirtime +" "+ day
+                    for ( time in airtime.get(day)!!){
+                        strAirtime = strAirtime +" "+ time
+                    }
+                    strAirtime = strAirtime
+                }
+            }
+            Text(text = "Airtime:"+strAirtime,fontSize = 18.sp)
             Text(text = program.description, fontSize = 18.sp)
             FavoritesSection(navController, title, favViewModel)
             program.episodes?.let {

--- a/app/src/main/java/com/wpi/audiojournal/view/ProgramOptionsView.kt
+++ b/app/src/main/java/com/wpi/audiojournal/view/ProgramOptionsView.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import com.wpi.audiojournal.ui.component.GetAirtimeMap
 import com.wpi.audiojournal.ui.component.Loading
 import com.wpi.audiojournal.ui.component.Menu
 import com.wpi.audiojournal.ui.component.PageSkeleton
@@ -11,12 +12,15 @@ import com.wpi.audiojournal.viewmodels.CategoryViewModel
 
 @Composable
 fun ProgramOptionsView(navController: NavController, title: String, name: String, viewModel: CategoryViewModel = viewModel()){
+
     LaunchedEffect(name) {
         viewModel.loadPrograms(name)
+
     }
 
     PageSkeleton(header = title) {
         Loading(data = viewModel.programs) {
+
             Menu(menuItems = it, navController = navController)
         }
     }


### PR DESCRIPTION
## Motivation
Add the airtime information to programs.
## Description
Used the schedule api to create a map of each airtime for each program. I load that at start of the app, and then use the map in program detailed view.
## Screenshot / Video
![image](https://user-images.githubusercontent.com/86576251/212415613-0e09374f-c5f0-43d0-b4ec-7ca718dea222.png)

## Checklist
- [x] Builds successfully
- [x] Tested in emulator
