### PR TITLE
Back button, resume last played bug fixed

### DIFF
--- a/app/src/main/java/com/wpi/audiojournal/navigation/NavGraph.kt
+++ b/app/src/main/java/com/wpi/audiojournal/navigation/NavGraph.kt
@@ -1,5 +1,6 @@
 package com.wpi.audiojournal.navigation
 
+import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavHostController
@@ -99,6 +100,10 @@ fun SetupNavGraph(navController: NavHostController, setColorScheme: (ColorScheme
 
             if (title != null && link != null && playTime != null) {
                     MediaPlayerView(title = title, uriString = link, playTime = playTime)
+            }
+            else{
+                Toast.makeText(LocalContext.current, "No previous program played", Toast.LENGTH_LONG).show()
+                MediaPlayerView(title = "Audio Journal", uriString = "", playTime = 0)
             }
         }
 

--- a/app/src/main/java/com/wpi/audiojournal/screen/SplashScreen.kt
+++ b/app/src/main/java/com/wpi/audiojournal/screen/SplashScreen.kt
@@ -37,7 +37,11 @@ fun SplashScreen(navController: NavController){
     LaunchedEffect(key1 = true){
         //delay(3000)
         delay(3000)
-        navController.navigate("home")
+        navController.navigate("home"){
+            popUpTo("loading") {
+                inclusive = true
+            }
+        }
     }
 
     Box(modifier = Modifier

--- a/app/src/main/java/com/wpi/audiojournal/ui/component/Player.kt
+++ b/app/src/main/java/com/wpi/audiojournal/ui/component/Player.kt
@@ -93,6 +93,7 @@ fun Controls(player: Player, title:String, playTime: Long, uri: String) {
         while(true) {
             position = player.currentPosition
             maxPosition = max(player.bufferedPosition, player.duration)
+            viewModel.addLastPlayed(title, uri, player.currentPosition)
             delay(500)
         }
     }
@@ -109,7 +110,6 @@ fun Controls(player: Player, title:String, playTime: Long, uri: String) {
         }
         player.addListener(listener)
         onDispose {
-            viewModel.addLastPlayed(title, uri, player.currentPosition)
             player.removeListener(listener)
         }
     }
@@ -145,7 +145,6 @@ fun Controls(player: Player, title:String, playTime: Long, uri: String) {
                     Icon(Icons.Default.Pause, "Pause")
                 else{
                     Icon(Icons.Default.PlayArrow, "Play")
-                    viewModel.addLastPlayed(title, uri, player.currentPosition)
                 }
             }
             IconButton(onClick = { seek(position.plus(30000)) }) {

--- a/app/src/main/java/com/wpi/audiojournal/view/HomeView.kt
+++ b/app/src/main/java/com/wpi/audiojournal/view/HomeView.kt
@@ -1,5 +1,6 @@
 package com.wpi.audiojournal.view
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
@@ -27,6 +28,7 @@ fun HomeView(
     navController: NavController,
     setColorScheme: (ColorScheme) -> Unit
 ) {
+    BackHandler {}
     val colors = LocalColorScheme.current
     val viewModel = FavoritesViewModel(StoreData(LocalContext.current))
     PageSkeleton(header = "Audio Journal") {


### PR DESCRIPTION
fixed back button redirecting from home page to loading screen, resume last played timestamp, and issue when no program previously played but resume last played clicked

## Motivation
Fixing bugs before app deployment

## Description
1. When on the home screen, you could previously click the back button, which would take you to the loading screen. Since that is not the intended behavior, the back button is disabled on the home screen because it may cause an issue with airtime if  enabled to close the app.
2. Intially, the time stamp when playing a program was only recorded in storage when the media player paused. Now, the timestamp is saved every second, allowing for audio to play when the app is run in the background, and saves when the app is closed.
3. Similar to the color scheme bug, since the values that the resume last broadcast screen needed would be null when the app is initally downloaded, I put in default values when no program was previously played, so the app does not navigate to a blank screen or crash.

## Screenshot / Video (Of default resume last played screen)
![image](https://user-images.githubusercontent.com/89553998/213946286-3a61b33d-fa7d-4aff-ac48-a2d68f7bfcf2.png)

## Checklist
- [x] Builds successfully
- [x] Tested in emulator
